### PR TITLE
Translate spec-driven development guide to Japanese

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,199 +1,182 @@
 <div align="center">
     <img src="./media/logo_small.webp"/>
     <h1>🌱 Spec Kit</h1>
-    <h3><em>Build high-quality software faster.</em></h3>
+    <h3><em>高品質なソフトウェアをより速く構築しましょう。</em></h3>
 </div>
 
 <p align="center">
-    <strong>An effort to allow organizations to focus on product scenarios rather than writing undifferentiated code with the help of Spec-Driven Development.</strong>
+    <strong>Spec-Driven Development（仕様駆動開発）の力を借りて、組織が非差別化コードの記述ではなくプロダクトシナリオに集中できるようにする取り組みです。</strong>
 </p>
 
 [![Release](https://github.com/github/spec-kit/actions/workflows/release.yml/badge.svg)](https://github.com/github/spec-kit/actions/workflows/release.yml)
 
 ---
 
-## Table of Contents
+## 目次
 
-- [🤔 What is Spec-Driven Development?](#-what-is-spec-driven-development)
-- [⚡ Get started](#-get-started)
-- [📚 Core philosophy](#-core-philosophy)
-- [🌟 Development phases](#-development-phases)
-- [🎯 Experimental goals](#-experimental-goals)
-- [🔧 Prerequisites](#-prerequisites)
-- [📖 Learn more](#-learn-more)
-- [Detailed process](#detailed-process)
-- [Troubleshooting](#troubleshooting)
+- [🤔 Spec-Driven Developmentとは？](#-spec-driven-developmentとは)
+- [⚡ はじめ方](#-はじめ方)
+- [📚 コア哲学](#-コア哲学)
+- [🌟 開発フェーズ](#-開発フェーズ)
+- [🎯 実験的な目標](#-実験的な目標)
+- [🔧 前提条件](#-前提条件)
+- [📖 詳しく知る](#-詳しく知る)
+- [詳細プロセス](#詳細プロセス)
+- [トラブルシューティング](#トラブルシューティング)
 
-## 🤔 What is Spec-Driven Development?
+## 🤔 Spec-Driven Developmentとは？
 
-Spec-Driven Development **flips the script** on traditional software development. For decades, code has been king — specifications were just scaffolding we built and discarded once the "real work" of coding began. Spec-Driven Development changes this: **specifications become executable**, directly generating working implementations rather than just guiding them.
+Spec-Driven Development（仕様駆動開発）は、従来のソフトウェア開発とは逆の発想です。長年にわたり、コードが主役でしたが、仕様書は「本番」の作業の足場として作られ、すぐに捨てられる存在でした。Spec-Driven Developmentは「何を作るか」「なぜ作るか」を重視し、仕様がプロダクトの中心となります。
 
-## ⚡ Get started
+## ⚡ はじめ方
 
-### 1. Install Specify
+### 1. Specifyのインストール
 
-Initialize your project depending on the coding agent you're using:
+使用するコーディングエージェントに応じてプロジェクトを初期化します。
 
 ```bash
 uvx --from git+https://github.com/github/spec-kit.git specify init <PROJECT_NAME>
 ```
 
-### 2. Create the spec
+### 2. 仕様書の作成
 
-Use the `/specify` command to describe what you want to build. Focus on the **what** and **why**, not the tech stack.
-
-```bash
-/specify Build an application that can help me organize my photos in separate photo albums. Albums are grouped by date and can be re-organized by dragging and dropping on the main page. Albums never other nested albums. Within each album, photos are previewed in a tile-like interface.
-```
-
-### 3. Create a technical implementation plan
-
-Use the `/plan` command to provide your tech stack and architecture choices.
+`/specify` コマンドで作りたいものを記述します。技術スタックではなく、**何を、なぜ作るか**に集中しましょう。
 
 ```bash
-/plan The application uses Vite with minimal number of libraries. Use vanilla HTML, CSS, and JavaScript as much as possible. Images are not uploaded anywhere and metadata is stored in a local SQLite database.
+/specify 写真をアルバムごとに整理するアプリケーションを作りたい。アルバムは日付ごとにグループ化され、メインページでドラッグ＆ドロップで再編成できる。アルバムは決して消えない。[...]
 ```
 
-### 4. Break down and implement
+### 3. 技術実装計画の作成
 
-Use `/tasks` to create an actionable task list, then ask your agent to implement the feature.
+`/plan` コマンドで技術スタックやアーキテクチャの方針を記述します。
 
-For detailed step-by-step instructions, see our [comprehensive guide](./spec-driven.md).
+```bash
+/plan アプリケーションはViteを使い、ライブラリは最小限に抑える。できるだけバニラHTML、CSS、JavaScriptを使用する。画像はアップロードせず、メタデータはローカルSQLiteデータベースに保存する。[...]
+```
 
-## 📚 Core philosophy
+### 4. 分割と実装
 
-Spec-Driven Development is a structured process that emphasizes:
+`/tasks` で実行可能なタスクリストを作成し、エージェントに実装を依頼しましょう。
 
-- **Intent-driven development** where specifications define the "_what_" before the "_how_"
-- **Rich specification creation** using guardrails and organizational principles
-- **Multi-step refinement** rather than one-shot code generation from prompts
-- **Heavy reliance** on advanced AI model capabilities for specification interpretation
+詳細な手順は[総合ガイド](./spec-driven.md)をご覧ください。
 
-## 🌟 Development phases
+## 📚 コア哲学
 
-| Phase | Focus | Key Activities |
+Spec-Driven Developmentは以下の原則を重視します：
+
+- **意図駆動開発**：仕様が「何を」定義し、「どうやって」は後から決定
+- **豊かな仕様作成**：ガードレールや組織的原則に基づく仕様化
+- **多段階の洗練**：プロンプト一発ではなく段階的な洗練
+- **AIモデルの高度な活用**：仕様解釈にAIの力を活用
+
+## 🌟 開発フェーズ
+
+| フェーズ | フォーカス | 主な活動 |
 |-------|-------|----------------|
-| **0-to-1 Development** ("Greenfield") | Generate from scratch | <ul><li>Start with high-level requirements</li><li>Generate specifications</li><li>Plan implementation steps</li><li>Build production-ready applications</li></ul> |
-| **Creative Exploration** | Parallel implementations | <ul><li>Explore diverse solutions</li><li>Support multiple technology stacks & architectures</li><li>Experiment with UX patterns</li></ul> |
-| **Iterative Enhancement** ("Brownfield") | Brownfield modernization | <ul><li>Add features iteratively</li><li>Modernize legacy systems</li><li>Adapt processes</li></ul> |
+| **0→1開発**（グリーンフィールド） | ゼロから構築 | <ul><li>高レベル要件からスタート</li><li>仕様書の作成</li><li>実装計画の立案</li><li>本番コードの構築</li></ul> |
+| **創造的探求** | 並列実装 | <ul><li>多様なソリューションの探求</li><li>複数技術スタック・アーキテクチャのサポート</li><li>UXパターンの実験</li></ul> |
+| **反復的改善**（ブラウンフィールド） | レガシーの近代化 | <ul><li>機能追加の反復</li><li>レガシーシステムの近代化</li><li>プロセスの適応</li></ul> |
 
-## 🎯 Experimental goals
+## 🎯 実験的な目標
 
-Our research and experimentation focus on:
+研究・実験のフォーカス：
 
-### Technology independence
+### 技術独立性
 
-- Create applications using diverse technology stacks
-- Validate the hypothesis that Spec-Driven Development is a process not tied to specific technologies, programming languages, or frameworks
+- 多様な技術スタックでアプリケーションを作成
+- Spec-Driven Developmentが技術・言語・フレームワークに依存しないプロセスであることを検証
 
-### Enterprise constraints
+### 企業制約
 
-- Demonstrate mission-critical application development
-- Incorporate organizational constraints (cloud providers, tech stacks, engineering practices)
-- Support enterprise design systems and compliance requirements
+- ミッションクリティカルなアプリケーションの開発
+- 組織的制約（クラウド、技術、エンジニアリング習慣）の取り込み
+- 企業向けデザインシステムやコンプライアンス要件への対応
 
-### User-centric development
+### ユーザー中心開発
 
-- Build applications for different user cohorts and preferences
-- Support various development approaches (from vibe-coding to AI-native development)
+- 多様なユーザー層・嗜好に合わせたアプリケーション作成
+- コーディングアプローチの多様性（バイブコーディング～AIネイティブ開発）
 
-### Creative & iterative processes
+### 創造的＆反復的プロセス
 
-- Validate the concept of parallel implementation exploration
-- Provide robust iterative feature development workflows
-- Extend processes to handle upgrades and modernization tasks  
+- 並列実装探求の概念検証
+- 強力な反復的機能開発ワークフローの提供
+- アップグレードや近代化タスクへのプロセス拡張
 
-## 🔧 Prerequisites
+## 🔧 前提条件
 
-- **Linux/macOS** (or WSL2 on Windows)
-- AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), or [Gemini CLI](https://github.com/google-gemini/gemini-cli)
-- [uv](https://docs.astral.sh/uv/) for package management
+- **Linux/macOS**（またはWindows上のWSL2）
+- AIコーディングエージェント：[Claude Code](https://www.anthropic.com/claude-code)、[GitHub Copilot](https://code.visualstudio.com/)、[Gemini CLI](https://github.com/google-gemini/gemini-cli)
+- パッケージ管理用 [uv](https://docs.astral.sh/uv/)
 - [Python 3.11+](https://www.python.org/downloads/)
 - [Git](https://git-scm.com/downloads)
 
-## 📖 Learn more
+## 📖 詳しく知る
 
-- **[Complete Spec-Driven Development Methodology](./spec-driven.md)** - Deep dive into the full process
-- **[Detailed Walkthrough](#detailed-process)** - Step-by-step implementation guide
+- **[Spec-Driven Development完全ガイド](./spec-driven.md)** - プロセスの詳細
+- **[詳細な実装手順](#詳細プロセス)** - ステップバイステップのガイド
 
 ---
 
-## Detailed process
+## 詳細プロセス
 
 <details>
-<summary>Click to expand the detailed step-by-step walkthrough</summary>
+<summary>詳細なステップバイステップ手順を表示</summary>
 
-You can use the Specify CLI to bootstrap your project, which will bring in the required artifacts in your environment. Run:
+Specify CLIを使ってプロジェクトをブートストラップできます。必要なアーティファクトが環境に導入されます。コマンド：
 
 ```bash
 specify init <project_name>
 ```
 
-Or initialize in the current directory:
+カレントディレクトリで初期化：
 
 ```bash
 specify init --here
 ```
 
-![Specify CLI bootstrapping a new project in the terminal](./media/specify_cli.gif)
+![Specify CLIが新規プロジェクトをターミナルでブートストラップ](./media/specify_cli.gif)
 
-You will be prompted to select the AI agent you are using. You can also proactively specify it directly in the terminal:
+使用するAIエージェントを選択するように促されます。直接指定も可能です：
 
 ```bash
 specify init <project_name> --ai claude
 specify init <project_name> --ai gemini
 specify init <project_name> --ai copilot
-# Or in current directory:
+# カレントディレクトリの場合：
 specify init --here --ai claude
 ```
 
-The CLI will check if you have Claude Code or Gemini CLI installed. If you do not, or you prefer to get the templates without checking for the right tools, use `--ignore-agent-tools` with your command:
+CLIはClaude CodeやGemini CLIのインストールを確認します。未インストール、あるいはテンプレートだけ欲しい場合は `--ignore-agent-tools` オプションを追加してください。
 
 ```bash
 specify init <project_name> --ai claude --ignore-agent-tools
 ```
 
-### **STEP 1:** Bootstrap the project
+### **STEP 1:** プロジェクトのブートストラップ
 
-Go to the project folder and run your AI agent. In our example, we're using `claude`.
+プロジェクトフォルダへ移動し、AIエージェントを起動します。ここでは `claude` を例にします。
 
-![Bootstrapping Claude Code environment](./media/bootstrap-claude-code.gif)
+![Claude Code環境のブートストラップ](./media/bootstrap-claude-code.gif)
 
-You will know that things are configured correctly if you see the `/specify`, `/plan`, and `/tasks` commands available.
+`/specify`, `/plan`, `/tasks` コマンドが使える状態になっていれば設定成功です。
 
-The first step should be creating a new project scaffolding. Use `/specify` command and then provide the concrete requirements for the project you want to develop.
+まずはプロジェクトの足場を作成します。`/specify` コマンドで具体的な要件を入力しましょう。
 
 >[!IMPORTANT]
->Be as explicit as possible about _what_ you are trying to build and _why_. **Do not focus on the tech stack at this point**.
+>「何を」「なぜ」作りたいのかを明確に記述しましょう。**技術スタックにはこの段階で触れないでください。**
 
-An example prompt:
+入力例：
 
 ```text
-Develop Taskify, a team productivity platform. It should allow users to create projects, add team members,
-assign tasks, comment and move tasks between boards in Kanban style. In this initial phase for this feature,
-let's call it "Create Taskify," let's have multiple users but the users will be declared ahead of time, predefined.
-I want five users in two different categories, one product manager and four engineers. Let's create three
-different sample projects. Let's have the standard Kanban columns for the status of each task, such as "To Do,"
-"In Progress," "In Review," and "Done." There will be no login for this application as this is just the very
-first testing thing to ensure that our basic features are set up. For each task in the UI for a task card,
-you should be able to change the current status of the task between the different columns in the Kanban work board.
-You should be able to leave an unlimited number of comments for a particular card. You should be able to, from that task
-card, assign one of the valid users. When you first launch Taskify, it's going to give you a list of the five users to pick
-from. There will be no password required. When you click on a user, you go into the main view, which displays the list of
-projects. When you click on a project, you open the Kanban board for that project. You're going to see the columns.
-You'll be able to drag and drop cards back and forth between different columns. You will see any cards that are
-assigned to you, the currently logged in user, in a different color from all the other ones, so you can quickly
-see yours. You can edit any comments that you make, but you can't edit comments that other people made. You can
-delete any comments that you made, but you can't delete comments anybody else made.
+Taskifyというチーム生産性プラットフォームを開発したい。ユーザーはプロジェクト作成・メンバー追加・タスク割り当て・コメント・タスクをカンバンで移動可能。初期ではユーザーは事前定義、5人（1人プロダクトマネージャ・4人エンジニア）、3つのサンプルプロジェクト。カンバンは「To Do」「In Progress」「In Review」「Done」。ログイン不要。UI上でタスクカードの状態変更、コメント追加・編集・削除（自分のみ）、タスクの担当割り当て。色分けで自分のタスク判別。プロジェクト選択後、カンバン表示。ドラッグ＆ドロップでカード移動可能。他人のコメントは編集・削除不可。
 ```
 
-After this prompt is entered, you should see Claude Code kick off the planning and spec drafting process. Claude Code will also trigger some of the built-in scripts to set up the repository.
+このプロンプト入力後、Claude Codeがプランニングや仕様作成を開始します。ビルトインスクリプトでリポジトリ設定も行われます。
 
-Once this step is completed, you should have a new branch created (e.g., `001-create-taskify`), as well as a new specification in the `specs/001-create-taskify` directory.
+完了すると新しいブランチ（例：`001-create-taskify`）と、`specs/001-create-taskify` ディレクトリに仕様書が作成されます。
 
-The produced specification should contain a set of user stories and functional requirements, as defined in the template.
-
-At this stage, your project folder contents should resemble the following:
+この時点でのプロジェクトフォルダ例：
 
 ```text
 ├── memory
@@ -216,35 +199,31 @@ At this stage, your project folder contents should resemble the following:
     └── tasks-template.md
 ```
 
-### **STEP 2:** Functional specification clarification
+### **STEP 2:** 機能仕様の明確化
 
-With the baseline specification created, you can go ahead and clarify any of the requirements that were not captured properly within the first shot attempt. For example, you could use a prompt like this within the same Claude Code session:
-
-```text
-For each sample project or project that you create there should be a variable number of tasks between 5 and 15
-tasks for each one randomly distributed into different states of completion. Make sure that there's at least
-one task in each stage of completion.
-```
-
-You should also ask Claude Code to validate the **Review & Acceptance Checklist**, checking off the things that are validated/pass the requirements, and leave the ones that are not unchecked. The following prompt can be used:
+ベース仕様作成後、抜け漏れ要件を明確化できます。例：
 
 ```text
-Read the review and acceptance checklist, and check off each item in the checklist if the feature spec meets the criteria. Leave it empty if it does not.
+各サンプルプロジェクトには5～15個のタスクをランダムに割り振り、すべての進行状態に最低1つずつタスクが存在するようにしてください。
 ```
 
-It's important to use the interaction with Claude Code as an opportunity to clarify and ask questions around the specification - **do not treat its first attempt as final**.
-
-### **STEP 3:** Generate a plan
-
-You can now be specific about the tech stack and other technical requirements. You can use the `/plan` command that is built into the project template with a prompt like this:
+Claude Codeに**レビュー＆受入チェックリスト**の検証も依頼できます。
 
 ```text
-We are going to generate this using .NET Aspire, using Postgres as the database. The frontend should use
-Blazor server with drag-and-drop task boards, real-time updates. There should be a REST API created with a projects API,
-tasks API, and a notifications API.
+レビュー＆受入チェックリストを読み、仕様が満たしていればチェックを入れてください。満たしていない場合は空欄のままにしてください。
 ```
 
-The output of this step will include a number of implementation detail documents, with your directory tree resembling this:
+初回仕様は確定ではありません。Claude Codeとのやり取りで積極的に質問・明確化しましょう。
+
+### **STEP 3:** プランの生成
+
+ここで技術スタックや詳細要件を明示します。`/plan` コマンド例：
+
+```text
+.NET Aspireを使用し、データベースはPostgres。フロントエンドはBlazorサーバー、ドラッグ＆ドロップ対応、リアルタイム更新。REST APIでプロジェクト・タスク・通知を管理。
+```
+
+この段階でディレクトリは下記のようになります：
 
 ```text
 .
@@ -276,103 +255,87 @@ The output of this step will include a number of implementation detail documents
     └── tasks-template.md
 ```
 
-Check the `research.md` document to ensure that the right tech stack is used, based on your instructions. You can ask Claude Code to refine it if any of the components stand out, or even have it check the locally-installed version of the platform/framework you want to use (e.g., .NET).
+`research.md` に技術スタックの調査内容が反映されているか確認しましょう。必要ならClaude Codeに修正依頼できます。
 
-Additionally, you might want to ask Claude Code to research details about the chosen tech stack if it's something that is rapidly changing (e.g., .NET Aspire, JS frameworks), with a prompt like this:
+技術スタックが急速に変化する場合は追加調査の依頼も推奨です：
 
 ```text
-I want you to go through the implementation plan and implementation details, looking for areas that could
-benefit from additional research as .NET Aspire is a rapidly changing library. For those areas that you identify that
-require further research, I want you to update the research document with additional details about the specific
-versions that we are going to be using in this Taskify application and spawn parallel research tasks to clarify
-any details using research from the web.
+.NET Aspireのような急速に進化するライブラリについては、実装計画や詳細ファイル内で追加調査が必要な部分を特定し、対応するリサーチタスクを並列で展開してください。Taskifyに使用するバージョンなど、具体的な情報をresearch.mdに追記してください。
 ```
 
-During this process, you might find that Claude Code gets stuck researching the wrong thing - you can help nudge it in the right direction with a prompt like this:
+Claude Codeが的外れな調査をした場合は、下記のように修正を促しましょう：
 
 ```text
-I think we need to break this down into a series of steps. First, identify a list of tasks
-that you would need to do during implementation that you're not sure of or would benefit
-from further research. Write down a list of those tasks. And then for each one of these tasks,
-I want you to spin up a separate research task so that the net results is we are researching
-all of those very specific tasks in parallel. What I saw you doing was it looks like you were
-researching .NET Aspire in general and I don't think that's gonna do much for us in this case.
-That's way too untargeted research. The research needs to help you solve a specific targeted question.
+まず実装時に不明点・追加調査が必要なタスクをリストアップし、それぞれ並列にリサーチタスクを展開してください。一般的な.NET Aspire情報の調査ではなく、課題解決に直結する具体的な調査が必要です。
 ```
 
 >[!NOTE]
->Claude Code might be over-eager and add components that you did not ask for. Ask it to clarify the rationale and the source of the change.
+>Claude Codeが余計なコンポーネントを追加することもあるので、理由や変更の根拠を確認しましょう。
 
-### **STEP 4:** Have Claude Code validate the plan
+### **STEP 4:** プランの検証
 
-With the plan in place, you should have Claude Code run through it to make sure that there are no missing pieces. You can use a prompt like this:
+プラン完成後、Claude Codeに内容監査を依頼しましょう：
 
 ```text
-Now I want you to go and audit the implementation plan and the implementation detail files.
-Read through it with an eye on determining whether or not there is a sequence of tasks that you need
-to be doing that are obvious from reading this. Because I don't know if there's enough here. For example,
-when I look at the core implementation, it would be useful to reference the appropriate places in the implementation
-details where it can find the information as it walks through each step in the core implementation or in the refinement.
+実装計画と詳細ファイルを監査し、明らかに実施すべきタスクの抜け漏れがないか確認してください。各ステップに関連する詳細情報への参照も付けてください。
 ```
 
-This helps refine the implementation plan and helps you avoid potential blind spots that Claude Code missed in its planning cycle. Once the initial refinement pass is complete, ask Claude Code to go through the checklist once more before you can get to the implementation.
-
-You can also ask Claude Code (if you have the [GitHub CLI](https://docs.github.com/en/github-cli/github-cli) installed) to go ahead and create a pull request from your current branch to `main` with a detailed description, to make sure that the effort is properly tracked.
+これで計画の精度が高まり、見落としを防げます。初回の洗練後は、Claude Codeに「過剰設計」箇所の確認も依頼しましょう。
 
 >[!NOTE]
->Before you have the agent implement it, it's also worth prompting Claude Code to cross-check the details to see if there are any over-engineered pieces (remember - it can be over-eager). If over-engineered components or decisions exist, you can ask Claude Code to resolve them. Ensure that Claude Code follows the [constitution](base/memory/constitution.md) as the foundational piece that it must adhere to when establishing the plan.
+>実装前に過剰設計部分の有無も要確認です。
 
-### STEP 5: Implementation
+### STEP 5: 実装
 
-Once ready, instruct Claude Code to implement your solution (example path included):
+準備ができたらClaude Codeに実装を指示します（例）：
 
 ```text
 implement specs/002-create-taskify/plan.md
 ```
 
-Claude Code will spring into action and will start creating the implementation.
+Claude Codeが自動で実装を進めます。
 
 >[!IMPORTANT]
->Claude Code will execute local CLI commands (such as `dotnet`) - make sure you have them installed on your machine.
+>Claude CodeはローカルCLIコマンド（dotnet等）を実行するため、事前にインストールしておいてください。
 
-Once the implementation step is done, ask Claude Code to try to run the application and resolve any emerging build errors. If the application runs, but there are _runtime errors_ that are not directly available to Claude Code through CLI logs (e.g., errors rendered in browser logs), copy and paste the error in Claude Code and have it attempt to resolve it.
+実装完了後はアプリ実行＆ビルドエラー対応を依頼しましょう。実行可能でもランタイムエラーが発生する場合は、追加で修正を依頼してください。
 
 </details>
 
 ---
 
-## Troubleshooting
+## トラブルシューティング
 
-### Git Credential Manager on Linux
+### LinuxでのGit Credential Manager
 
-If you're having issues with Git authentication on Linux, you can install Git Credential Manager:
+LinuxでGit認証に問題がある場合は以下でインストール可能です：
 
 ```bash
 #!/bin/bash
 set -e
-echo "Downloading Git Credential Manager v2.6.1..."
+echo "Git Credential Manager v2.6.1のダウンロード中..."
 wget https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.6.1/gcm-linux_amd64.2.6.1.deb
-echo "Installing Git Credential Manager..."
+echo "Git Credential Managerのインストール中..."
 sudo dpkg -i gcm-linux_amd64.2.6.1.deb
-echo "Configuring Git to use GCM..."
+echo "Gitの認証ヘルパーをmanagerに設定中..."
 git config --global credential.helper manager
-echo "Cleaning up..."
+echo "後処理中..."
 rm gcm-linux_amd64.2.6.1.deb
 ```
 
-## Maintainers
+## メンテナー
 
 - Den Delimarsky ([@localden](https://github.com/localden))
 - John Lam ([@jflam](https://github.com/jflam))
 
-## Support
+## サポート
 
-For support, please open a [GitHub issue](https://github.com/github/spec-kit/issues/new). We welcome bug reports, feature requests, and questions about using Spec-Driven Development.
+サポートが必要な場合は[GitHub Issue](https://github.com/github/spec-kit/issues/new)を作成してください。バグ報告・機能要望・Spec-Driven Developmentの利用質問を歓迎します。
 
-## Acknowledgements
+## 謝辞
 
-This project is heavily influenced by and based on the work and research of [John Lam](https://github.com/jflam).
+本プロジェクトは[John Lam](https://github.com/jflam)の研究成果に大きく基づいています。
 
-## License
+## ライセンス
 
-This project is licensed under the terms of the MIT open source license. Please refer to the [LICENSE](./LICENSE) file for the full terms.
+本プロジェクトはMITライセンスで公開されています。詳細は[LICENSE](./LICENSE)ファイルをご参照ください。

--- a/spec-driven.md
+++ b/spec-driven.md
@@ -1,153 +1,153 @@
-# 仕様駆動開発 (Specification-Driven Development, SDD)
+# Specification-Driven Development (SDD)
 
-## 権力構造の逆転
+## The Power Inversion
 
-何十年もの間、コードが主役でした。仕様書はコードに従属するものであり、開発の「本番作業」が始まると捨てられる足場のようなものでした。私たちはPRD（プロダクト要件文書）を作成して開発を導き、設計文書を作成して実装を支援し、アーキテクチャを視覚化するために図を描きました。しかし、これらは常にコード自体に従属していました。コードが真実であり、それ以外はせいぜい善意の産物でした。コードが唯一の真実の源であり、コードが進化するにつれて仕様書はほとんど追随しませんでした。コードと実装が一体であるため、コードから離れて並行して実装を行うのは容易ではありません。
+For decades, code has been king. Specifications served code—they were the scaffolding we built and then discarded once the "real work" of coding began. We wrote PRDs to guide development, created design docs to inform implementation, drew diagrams to visualize architecture. But these were always subordinate to the code itself. Code was truth. Everything else was, at best, good intentions. Code was the source of truth, as it moved forward, and spec's rarely kept pace. As the asset (code) and the implementation are one, it's not easy to have a parallel implementation without trying to build from the code.
 
-仕様駆動開発（SDD）は、この権力構造を逆転させます。仕様書はコードに従属するのではなく、コードが仕様書に従属します。PRD（プロダクト要件文書-仕様書）は実装のガイドではなく、実装を生成する源泉です。技術計画はコーディングを支援する文書ではなく、コードを生成するための正確な定義です。これはソフトウェア開発の方法を改善するだけでなく、開発を駆動するものを根本的に再考するものです。
+Spec-Driven Development (SDD) inverts this power structure. Specifications don't serve code—code serves specifications. The (Product Requirements Document-Specification) PRD isn't a guide for implementation; it's the source that generates implementation. Technical plans aren't documents that inform coding; they're precise definitions that produce code. This isn't an incremental improvement to how we build software. It's a fundamental rethinking of what drives development.
 
-仕様と実装の間のギャップは、ソフトウェア開発の黎明期から悩みの種でした。私たちはこれを埋めるために、より良い文書化、より詳細な要件、より厳格なプロセスを試みてきました。しかし、これらのアプローチはギャップを避けられないものとして受け入れており、ギャップを狭めることはできても完全に排除することはできませんでした。SDDは、仕様書や仕様から生まれる具体的な実装計画を実行可能にすることで、このギャップを排除します。仕様から実装計画がコードを生成する場合、ギャップは存在せず、変換のみが存在します。
+The gap between specification and implementation has plagued software development since its inception. We've tried to bridge it with better documentation, more detailed requirements, stricter processes. These approaches fail because they accept the gap as inevitable. They try to narrow it but never eliminate it. SDD eliminates the gap by making specifications or and their concrete implementation plans born from the specification executable. When specifications to implementation plans generate code, there is no gap—only transformation.
 
-この変革は、AIが複雑な仕様を理解し、実装計画を作成できるようになったことで可能になりました。しかし、構造のないAI生成は混乱を引き起こします。SDDは、仕様書とその後の実装計画を通じて、正確で完全かつ曖昧さのない構造を提供します。仕様書は主要な成果物となり、コードは特定の言語やフレームワークでの表現（実装計画からの実装）となります。
+This transformation is now possible because AI can understand and implement complex specifications, and create detailed implementation plans. But raw AI generation without structure produces chaos. SDD provides that structure through specifications and subsequent implementation plans that are precise, complete, and unambiguous enough to generate working systems. The specification becomes the primary artifact. Code becomes its expression (as an implementation from the implementation plan) in a particular language and framework.
 
-この新しい世界では、ソフトウェアの保守は仕様書の進化を意味します。開発チームの意図は、自然言語（「意図駆動開発」）、設計資産、コア原則、その他のガイドラインで表現されます。開発の共通言語はより高いレベルに移行し、コードは最後の一里を担うものとなります。
+In this new world, maintaining software means evolving specifications. The intent of the development team is expressed in natural language ("**intent-driven development**"), design assets, core principles and other guidelines . The **lingua franca** of development moves to a higher-level, and code is the last-mile approach.
 
-デバッグは、誤ったコードを生成する仕様書とその実装計画を修正することを意味します。リファクタリングは、明確さのための再構築を意味します。開発ワークフロー全体が、仕様書を真実の中心的な源泉とし、実装計画とコードを継続的に再生成される成果物として再編成されます。新機能を追加したり、新しい並行実装を作成したりすることは、仕様書を再訪し、新しい実装計画を作成することを意味します。このプロセスは、0 -> 1, (1', ..), 2, 3, N という形で進行します。
+Debugging means fixing specifications and their implementation plans that generate incorrect code. Refactoring means restructuring for clarity. The entire development workflow reorganizes around specifications as the central source of truth, with implementation plans and code as the continuously regenerated output. Updating apps with new features or creating a new parallel implementation because we are creative beings, means revisiting the specification and creating new implementation plans. This process is therefore a 0 -> 1, (1', ..), 2, 3, N.
 
-開発チームは、創造性、実験、批判的思考に集中します。
+The development team focuses in on their creativity, experimentation, their critical thinking.
 
-## 実践におけるSDDワークフロー
+## The SDD Workflow in Practice
 
-ワークフローは、しばしば曖昧で不完全なアイデアから始まります。AIとの反復的な対話を通じて、このアイデアは包括的なPRDに進化します。AIは明確化の質問を行い、エッジケースを特定し、正確な受け入れ基準を定義するのを支援します。従来の開発では数日かかる会議や文書作成が、集中した仕様作業で数時間で完了します。これにより、従来のSDLC（ソフトウェア開発ライフサイクル）が変革され、要件と設計が離散的なフェーズではなく、継続的な活動となります。これは、チームプロセスをサポートするものであり、チームレビューされた仕様が表現され、ブランチで作成され、マージされます。
+The workflow begins with an idea—often vague and incomplete. Through iterative dialogue with AI, this idea becomes a comprehensive PRD. The AI asks clarifying questions, identifies edge cases, and helps define precise acceptance criteria. What might take days of meetings and documentation in traditional development happens in hours of focused specification work. This transforms the traditional SDLC—requirements and design become continuous activities rather than discrete phases. This is supportive of a **team process**, that's team reviewed-specifications are expressed and versioned, created in branches, and merged.
 
-プロダクトマネージャーが受け入れ基準を更新すると、実装計画は影響を受けた技術的決定を自動的にフラグ付けします。アーキテクトがより良いパターンを発見すると、PRDは新しい可能性を反映するように更新されます。
+When a product manager updates acceptance criteria, implementation plans automatically flag affected technical decisions. When an architect discovers a better pattern, the PRD updates to reflect new possibilities.
 
-仕様プロセス全体を通じて、リサーチエージェントが重要なコンテキストを収集します。ライブラリの互換性、パフォーマンスベンチマーク、セキュリティの影響を調査します。組織の制約が自動的に発見され、適用されます。たとえば、会社のデータベース標準、認証要件、デプロイメントポリシーがすべての仕様にシームレスに統合されます。
+Throughout this specification process, research agents gather critical context. They investigate library compatibility, performance benchmarks, and security implications. Organizational constraints are discovered and applied automatically—your company's database standards, authentication requirements, and deployment policies seamlessly integrate into every specification.
 
-PRDから、AIは要件を技術的な決定にマッピングする実装計画を生成します。すべての技術選択には文書化された根拠があります。すべてのアーキテクチャ決定は特定の要件に遡ります。このプロセス全体を通じて、一貫性の検証が品質を継続的に向上させます。AIは、曖昧さ、矛盾、ギャップについて仕様を分析します。これは一度限りのゲートではなく、継続的な改善プロセスです。
+From the PRD, AI generates implementation plans that map requirements to technical decisions. Every technology choice has documented rationale. Every architectural decision traces back to specific requirements. Throughout this process, consistency validation continuously improves quality. AI analyzes specifications for ambiguity, contradictions, and gaps—not as a one-time gate, but as an ongoing refinement.
 
-仕様とその実装計画が十分に安定すると、コード生成が開始されますが、「完成」している必要はありません。初期の生成は探索的である場合があります。仕様が実際に意味をなすかどうかをテストします。ドメインの概念はデータモデルになります。ユーザーストーリーはAPIエンドポイントになります。受け入れシナリオはテストになります。これにより、仕様を通じて開発とテストが統合されます。テストシナリオはコードの後に書かれるのではなく、実装とテストの両方を生成する仕様の一部です。
+Code generation begins as soon as specifications and their implementation plans are stable enough, but they do not have to be "complete." Early generations might be exploratory—testing whether the specification makes sense in practice. Domain concepts become data models. User stories become API endpoints. Acceptance scenarios become tests. This merges development and testing through specification—test scenarios aren't written after code, they're part of the specification that generates both implementation and tests.
 
-フィードバックループは初期開発を超えて拡張されます。運用メトリクスやインシデントは、ホットフィックスをトリガーするだけでなく、次回の再生成のために仕様を更新します。パフォーマンスのボトルネックは新しい非機能要件になります。セキュリティの脆弱性は、すべての将来の生成に影響を与える制約になります。この仕様、実装、運用現実の間の反復的なダンスが、真の理解が生まれる場所であり、従来のSDLCが継続的な進化に変わる場所です。
+The feedback loop extends beyond initial development. Production metrics and incidents don't just trigger hotfixes—they update specifications for the next regeneration. Performance bottlenecks become new non-functional requirements. Security vulnerabilities become constraints that affect all future generations. This iterative dance between specification, implementation, and operational reality is where true understanding emerges and where the traditional SDLC transforms into a continuous evolution.
 
-## なぜ今SDDが重要なのか
+## Why SDD Matters Now
 
-3つのトレンドがSDDを可能にし、必要不可欠なものにしています：
+Three trends make SDD not just possible but necessary:
 
-1つ目、AIの能力が自然言語仕様から信頼性の高い動作コードを生成できる閾値に達しました。これは開発者を置き換えるものではなく、仕様から実装への機械的な変換を自動化することで彼らの効果を増幅するものです。探索と創造性を増幅し、「やり直し」を容易にし、追加や削除、批判的思考をサポートします。
+First, AI capabilities have reached a threshold where natural language specifications can reliably generate working code. This isn't about replacing developers—it's about amplifying their effectiveness by automating the mechanical translation from specification to implementation. It can amplify exploration and creativity, it can support "start-over" easily, it supports addition subtraction and critical thinking.
 
-2つ目、ソフトウェアの複雑さが指数関数的に増加し続けています。現代のシステムは、数十のサービス、フレームワーク、依存関係を統合しています。手動プロセスを通じてこれらすべての部分を元の意図と一致させ続けることはますます困難になっています。SDDは、仕様駆動の生成を通じて体系的な整合性を提供します。フレームワークは、人間中心ではなくAI中心のサポートを提供するよう進化するか、再利用可能なコンポーネントを中心に設計される可能性があります。
+Second, software complexity continues to grow exponentially. Modern systems integrate dozens of services, frameworks, and dependencies. Keeping all these pieces aligned with original intent through manual processes becomes increasingly difficult. SDD provides systematic alignment through specification-driven generation. Frameworks may evolve to provide AI-first support, not human-first support, or architect around reusable components.
 
-3つ目、変化のペースが加速しています。要件はこれまで以上に急速に変化します。ピボットはもはや例外ではなく、期待されるものです。現代のプロダクト開発は、ユーザーフィードバック、市場状況、競争圧力に基づいて迅速な反復を要求します。従来の開発では、これらの変更を混乱として扱います。各ピボットは、文書化、設計、コードを手動で伝播する必要があります。その結果、速度を制限する慎重な更新か、技術的負債を蓄積する迅速で無謀な変更のいずれかになります。
+Third, the pace of change accelerates. Requirements change far more rapidly today than ever before. Pivoting is no longer exceptional—it's expected. Modern product development demands rapid iteration based on user feedback, market conditions, and competitive pressures. Traditional development treats these changes as disruptions. Each pivot requires manually propagating changes through documentation, design, and code. The result is either slow, careful updates that limit velocity, or fast, reckless changes that accumulate technical debt.
 
-SDDは、「もしアプリケーションを再実装または変更してビジネスニーズを促進し、Tシャツをより多く販売する必要がある場合、どのように実装し、実験するか？」といったシミュレーション実験をサポートできます。
+SDD can support what-if/simulation experiments, "If we need to re-implement or change the application to promote a business need to sell more T-shirts, how would we implement and experiment for that?".
 
-SDDは、要件の変更を障害ではなく通常のワークフローに変えます。仕様が実装を駆動する場合、ピボットは手動の書き換えではなく体系的な再生成になります。PRDのコア要件を変更すると、影響を受けた実装計画が自動的に更新されます。ユーザーストーリーを変更すると、対応するAPIエンドポイントが再生成されます。これは初期開発だけでなく、避けられない変更を通じてエンジニアリングの速度を維持することに関するものです。
+SDD transforms requirement changes from obstacles into normal workflow. When specifications drive implementation, pivots become systematic regenerations rather than manual rewrites. Change a core requirement in the PRD, and affected implementation plans update automatically. Modify a user story, and corresponding API endpoints regenerate. This isn't just about initial development—it's about maintaining engineering velocity through inevitable changes.
 
-## コア原則
+## Core Principles
 
-**共通言語としての仕様書**: 仕様書が主要な成果物となります。コードは特定の言語やフレームワークでの表現となります。ソフトウェアの保守は仕様書の進化を意味します。
+**Specifications as the Lingua Franca**: The specification becomes the primary artifact. Code becomes its expression in a particular language and framework. Maintaining software means evolving specifications.
 
-**実行可能な仕様書**: 仕様書は、動作するシステムを生成するのに十分な正確さ、完全性、曖昧さのなさを持つ必要があります。これにより、意図と実装のギャップが排除されます。
+**Executable Specifications**: Specifications must be precise, complete, and unambiguous enough to generate working systems. This eliminates the gap between intent and implementation.
 
-**継続的な改善**: 一貫性の検証は一度限りのゲートではなく、継続的に行われます。AIは、曖昧さ、矛盾、ギャップについて仕様を分析します。
+**Continuous Refinement**: Consistency validation happens continuously, not as a one-time gate. AI analyzes specifications for ambiguity, contradictions, and gaps as an ongoing process.
 
-**リサーチ駆動のコンテキスト**: リサーチエージェントが仕様プロセス全体を通じて重要なコンテキストを収集し、技術的な選択肢、パフォーマンスの影響、組織の制約を調査します。
+**Research-Driven Context**: Research agents gather critical context throughout the specification process, investigating technical options, performance implications, and organizational constraints.
 
-**双方向フィードバック**: 運用現実が仕様の進化を通知します。メトリクス、インシデント、運用から得られた学びが仕様の改善の入力となります。
+**Bidirectional Feedback**: Production reality informs specification evolution. Metrics, incidents, and operational learnings become inputs for specification refinement.
 
-**探索のためのブランチング**: 同じ仕様から複数の実装アプローチを生成し、パフォーマンス、保守性、ユーザーエクスペリエンス、コストなどの異なる最適化目標を探索します。
+**Branching for Exploration**: Generate multiple implementation approaches from the same specification to explore different optimization targets—performance, maintainability, user experience, cost.
 
-## 実装アプローチ
+## Implementation Approaches
 
-今日、SDDを実践するには、既存のツールを組み合わせ、このプロセス全体を通じて規律を維持する必要があります。この方法論は以下を使用して実践できます：
+Today, practicing SDD requires assembling existing tools and maintaining discipline throughout the process. The methodology can be practiced with:
 
-- 反復的な仕様開発のためのAIアシスタント
-- 技術的なコンテキストを収集するためのリサーチエージェント
-- 仕様を実装に変換するコード生成ツール
-- 仕様優先のワークフローに適応したバージョン管理システム
-- 仕様文書のAI分析による一貫性チェック
+- AI assistants for iterative specification development
+- Research agents for gathering technical context
+- Code generation tools for translating specifications to implementation
+- Version control systems adapted for specification-first workflows
+- Consistency checking through AI analysis of specification documents
 
-重要なのは、仕様書を真実の源泉とし、コードを仕様に従属する生成された成果物として扱うことです。
+The key is treating specifications as the source of truth, with code as the generated output that serves the specification rather than the other way around.
 
-## ClaudeコマンドによるSDDの効率化
+## Streamlining SDD with Claude Commands
 
-SDDの方法論は、仕様と計画のワークフローを自動化する2つの強力なClaudeコマンドによって大幅に強化されます。
+The SDD methodology is significantly enhanced through two powerful Claude commands that automate the specification and planning workflow:
 
-### `new_feature` コマンド
+### The `new_feature` Command
 
-このコマンドは、シンプルな機能の説明（ユーザープロンプト）を完全で構造化された仕様に変換し、自動的にリポジトリを管理します：
+This command transforms a simple feature description (the user-prompt) into a complete, structured specification with automatic repository management:
 
-1. **自動機能番号付け**: 既存の仕様をスキャンして次の機能番号を決定（例: 001, 002, 003）
-2. **ブランチ作成**: 説明からセマンティックなブランチ名を生成し、自動的に作成
-3. **テンプレートベースの生成**: 機能仕様テンプレートをコピーして要件に合わせてカスタマイズ
-4. **ディレクトリ構造**: 関連するすべてのドキュメントのために`specs/[branch-name]/`構造を作成
+1. **Automatic Feature Numbering**: Scans existing specs to determine the next feature number (e.g., 001, 002, 003)
+2. **Branch Creation**: Generates a semantic branch name from your description and creates it automatically
+3. **Template-Based Generation**: Copies and customizes the feature specification template with your requirements
+4. **Directory Structure**: Creates the proper `specs/[branch-name]/` structure for all related documents
 
-### `generate_plan` コマンド
+### The `generate_plan` Command
 
-機能仕様が存在すると、このコマンドは包括的な実装計画を作成します：
+Once a feature specification exists, this command creates a comprehensive implementation plan:
 
-1. **仕様分析**: 機能要件、ユーザーストーリー、受け入れ基準を読み取り理解
-2. **憲法準拠**: プロジェクト憲法とアーキテクチャ原則との整合性を確保
-3. **技術的翻訳**: ビジネス要件を技術アーキテクチャと実装の詳細に変換
-4. **詳細な文書化**: データモデル、API契約、テストシナリオのサポート文書を生成
-5. **手動テスト計画**: 各ユーザーストーリーのステップバイステップの検証手順を作成
+1. **Specification Analysis**: Reads and understands the feature requirements, user stories, and acceptance criteria
+2. **Constitutional Compliance**: Ensures alignment with project constitution and architectural principles
+3. **Technical Translation**: Converts business requirements into technical architecture and implementation details
+4. **Detailed Documentation**: Generates supporting documents for data models, API contracts, and test scenarios
+5. **Manual Testing Plans**: Creates step-by-step validation procedures for each user story
 
-### 例: チャット機能の構築
+### Example: Building a Chat Feature
 
-これらのコマンドが従来の開発ワークフローをどのように変革するかを示します：
+Here's how these commands transform the traditional development workflow:
 
-**従来のアプローチ:**
+**Traditional Approach:**
 ```
-1. ドキュメントでPRDを書く（2〜3時間）
-2. 設計文書を作成（2〜3時間）
-3. プロジェクト構造を手動で設定（30分）
-4. 技術仕様を書く（3〜4時間）
-5. テスト計画を作成（2時間）
-合計: ~12時間の文書作業
+1. Write a PRD in a document (2-3 hours)
+2. Create design documents (2-3 hours)
+3. Set up project structure manually (30 minutes)
+4. Write technical specifications (3-4 hours)
+5. Create test plans (2 hours)
+Total: ~12 hours of documentation work
 ```
 
-**SDDとコマンドのアプローチ:**
+**SDD with Commands Approach:**
 ```bash
-# ステップ1: 機能仕様を作成（5分）
-/new_feature リアルタイムチャットシステム（メッセージ履歴とユーザーの存在感を含む）
+# Step 1: Create the feature specification (5 minutes)
+/new_feature Real-time chat system with message history and user presence
 
-# これにより自動的に以下が行われます：
-# - ブランチ"003-chat-system"を作成
-# - specs/003-chat-system/feature-spec.mdを生成
-# - 構造化された要件で内容を埋める
+# This automatically:
+# - Creates branch "003-chat-system"
+# - Generates specs/003-chat-system/feature-spec.md
+# - Populates it with structured requirements
 
-# ステップ2: 実装計画を生成（10分）
-/generate_plan WebSocketを使用したリアルタイムメッセージング、PostgreSQLを使用した履歴、Redisを使用した存在感
+# Step 2: Generate implementation plan (10 minutes)
+/generate_plan WebSocket for real-time messaging, PostgreSQL for history, Redis for presence
 
-# これにより以下が自動的に作成されます：
+# This automatically creates:
 # - specs/003-chat-system/implementation-plan.md
 # - specs/003-chat-system/implementation-details/
-#   - 00-research.md（WebSocketライブラリの比較）
-#   - 02-data-model.md（メッセージとユーザースキーマ）
-#   - 03-api-contracts.md（WebSocketイベント、RESTエンドポイント）
-#   - 06-contract-tests.md（メッセージフローシナリオ）
-#   - 08-inter-library-tests.md（データベース-WebSocket統合）
+#   - 00-research.md (WebSocket library comparisons)
+#   - 02-data-model.md (Message and User schemas)
+#   - 03-api-contracts.md (WebSocket events, REST endpoints)
+#   - 06-contract-tests.md (Message flow scenarios)
+#   - 08-inter-library-tests.md (Database-WebSocket integration)
 # - specs/003-chat-system/manual-testing.md
 ```
 
-15分で以下が得られます：
-- ユーザーストーリーと受け入れ基準を含む完全な機能仕様
-- 技術選択とその根拠を含む詳細な実装計画
-- コード生成の準備が整ったAPI契約とデータモデル
-- 自動テストと手動テストの両方の包括的なテストシナリオ
-- すべてのドキュメントが機能ブランチに適切にバージョン管理
+In 15 minutes, you have:
+- A complete feature specification with user stories and acceptance criteria
+- A detailed implementation plan with technology choices and rationale
+- API contracts and data models ready for code generation
+- Comprehensive test scenarios for both automated and manual testing
+- All documents properly versioned in a feature branch
 
-### 構造化された自動化の力
+### The Power of Structured Automation
 
-これらのコマンドは時間を節約するだけでなく、一貫性と完全性を強制します：
+These commands don't just save time—they enforce consistency and completeness:
 
-1. **詳細の見落としなし**: テンプレートにより、非機能要件からエラーハンドリングまで、すべての側面が考慮されます
-2. **追跡可能な決定**: すべての技術的選択が特定の要件にリンクされます
-3. **生きた文書**: 仕様がコードと同期し続けるため、コードを生成します
-4. **迅速な反復**: 要件を変更し、計画を数分で再生成
+1. **No Forgotten Details**: Templates ensure every aspect is considered, from non-functional requirements to error handling
+2. **Traceable Decisions**: Every technical choice links back to specific requirements
+3. **Living Documentation**: Specifications stay in sync with code because they generate it
+4. **Rapid Iteration**: Change requirements and regenerate plans in minutes, not days
 
-これらのコマンドは、仕様を静的な文書ではなく、実行可能な成果物として扱うことで、SDDの原則を体現しています。仕様プロセスを必要悪から開発の推進力に変えます。
+The commands embody SDD principles by treating specifications as executable artifacts rather than static documents. They transform the specification process from a necessary evil into the driving force of development.
 
 ### Template-Driven Quality: How Structure Constrains LLMs for Better Outcomes
 

--- a/spec-driven.md
+++ b/spec-driven.md
@@ -1,153 +1,153 @@
-# Specification-Driven Development (SDD)
+# 仕様駆動開発 (Specification-Driven Development, SDD)
 
-## The Power Inversion
+## 権力構造の逆転
 
-For decades, code has been king. Specifications served code—they were the scaffolding we built and then discarded once the "real work" of coding began. We wrote PRDs to guide development, created design docs to inform implementation, drew diagrams to visualize architecture. But these were always subordinate to the code itself. Code was truth. Everything else was, at best, good intentions. Code was the source of truth, as it moved forward, and spec's rarely kept pace. As the asset (code) and the implementation are one, it's not easy to have a parallel implementation without trying to build from the code.
+何十年もの間、コードが主役でした。仕様書はコードに従属するものであり、開発の「本番作業」が始まると捨てられる足場のようなものでした。私たちはPRD（プロダクト要件文書）を作成して開発を導き、設計文書を作成して実装を支援し、アーキテクチャを視覚化するために図を描きました。しかし、これらは常にコード自体に従属していました。コードが真実であり、それ以外はせいぜい善意の産物でした。コードが唯一の真実の源であり、コードが進化するにつれて仕様書はほとんど追随しませんでした。コードと実装が一体であるため、コードから離れて並行して実装を行うのは容易ではありません。
 
-Spec-Driven Development (SDD) inverts this power structure. Specifications don't serve code—code serves specifications. The (Product Requirements Document-Specification) PRD isn't a guide for implementation; it's the source that generates implementation. Technical plans aren't documents that inform coding; they're precise definitions that produce code. This isn't an incremental improvement to how we build software. It's a fundamental rethinking of what drives development.
+仕様駆動開発（SDD）は、この権力構造を逆転させます。仕様書はコードに従属するのではなく、コードが仕様書に従属します。PRD（プロダクト要件文書-仕様書）は実装のガイドではなく、実装を生成する源泉です。技術計画はコーディングを支援する文書ではなく、コードを生成するための正確な定義です。これはソフトウェア開発の方法を改善するだけでなく、開発を駆動するものを根本的に再考するものです。
 
-The gap between specification and implementation has plagued software development since its inception. We've tried to bridge it with better documentation, more detailed requirements, stricter processes. These approaches fail because they accept the gap as inevitable. They try to narrow it but never eliminate it. SDD eliminates the gap by making specifications or and their concrete implementation plans born from the specification executable. When specifications to implementation plans generate code, there is no gap—only transformation.
+仕様と実装の間のギャップは、ソフトウェア開発の黎明期から悩みの種でした。私たちはこれを埋めるために、より良い文書化、より詳細な要件、より厳格なプロセスを試みてきました。しかし、これらのアプローチはギャップを避けられないものとして受け入れており、ギャップを狭めることはできても完全に排除することはできませんでした。SDDは、仕様書や仕様から生まれる具体的な実装計画を実行可能にすることで、このギャップを排除します。仕様から実装計画がコードを生成する場合、ギャップは存在せず、変換のみが存在します。
 
-This transformation is now possible because AI can understand and implement complex specifications, and create detailed implementation plans. But raw AI generation without structure produces chaos. SDD provides that structure through specifications and subsequent implementation plans that are precise, complete, and unambiguous enough to generate working systems. The specification becomes the primary artifact. Code becomes its expression (as an implementation from the implementation plan) in a particular language and framework.
+この変革は、AIが複雑な仕様を理解し、実装計画を作成できるようになったことで可能になりました。しかし、構造のないAI生成は混乱を引き起こします。SDDは、仕様書とその後の実装計画を通じて、正確で完全かつ曖昧さのない構造を提供します。仕様書は主要な成果物となり、コードは特定の言語やフレームワークでの表現（実装計画からの実装）となります。
 
-In this new world, maintaining software means evolving specifications. The intent of the development team is expressed in natural language ("**intent-driven development**"), design assets, core principles and other guidelines . The **lingua franca** of development moves to a higher-level, and code is the last-mile approach.
+この新しい世界では、ソフトウェアの保守は仕様書の進化を意味します。開発チームの意図は、自然言語（「意図駆動開発」）、設計資産、コア原則、その他のガイドラインで表現されます。開発の共通言語はより高いレベルに移行し、コードは最後の一里を担うものとなります。
 
-Debugging means fixing specifications and their implementation plans that generate incorrect code. Refactoring means restructuring for clarity. The entire development workflow reorganizes around specifications as the central source of truth, with implementation plans and code as the continuously regenerated output. Updating apps with new features or creating a new parallel implementation because we are creative beings, means revisiting the specification and creating new implementation plans. This process is therefore a 0 -> 1, (1', ..), 2, 3, N.
+デバッグは、誤ったコードを生成する仕様書とその実装計画を修正することを意味します。リファクタリングは、明確さのための再構築を意味します。開発ワークフロー全体が、仕様書を真実の中心的な源泉とし、実装計画とコードを継続的に再生成される成果物として再編成されます。新機能を追加したり、新しい並行実装を作成したりすることは、仕様書を再訪し、新しい実装計画を作成することを意味します。このプロセスは、0 -> 1, (1', ..), 2, 3, N という形で進行します。
 
-The development team focuses in on their creativity, experimentation, their critical thinking.
+開発チームは、創造性、実験、批判的思考に集中します。
 
-## The SDD Workflow in Practice
+## 実践におけるSDDワークフロー
 
-The workflow begins with an idea—often vague and incomplete. Through iterative dialogue with AI, this idea becomes a comprehensive PRD. The AI asks clarifying questions, identifies edge cases, and helps define precise acceptance criteria. What might take days of meetings and documentation in traditional development happens in hours of focused specification work. This transforms the traditional SDLC—requirements and design become continuous activities rather than discrete phases. This is supportive of a **team process**, that's team reviewed-specifications are expressed and versioned, created in branches, and merged.
+ワークフローは、しばしば曖昧で不完全なアイデアから始まります。AIとの反復的な対話を通じて、このアイデアは包括的なPRDに進化します。AIは明確化の質問を行い、エッジケースを特定し、正確な受け入れ基準を定義するのを支援します。従来の開発では数日かかる会議や文書作成が、集中した仕様作業で数時間で完了します。これにより、従来のSDLC（ソフトウェア開発ライフサイクル）が変革され、要件と設計が離散的なフェーズではなく、継続的な活動となります。これは、チームプロセスをサポートするものであり、チームレビューされた仕様が表現され、ブランチで作成され、マージされます。
 
-When a product manager updates acceptance criteria, implementation plans automatically flag affected technical decisions. When an architect discovers a better pattern, the PRD updates to reflect new possibilities.
+プロダクトマネージャーが受け入れ基準を更新すると、実装計画は影響を受けた技術的決定を自動的にフラグ付けします。アーキテクトがより良いパターンを発見すると、PRDは新しい可能性を反映するように更新されます。
 
-Throughout this specification process, research agents gather critical context. They investigate library compatibility, performance benchmarks, and security implications. Organizational constraints are discovered and applied automatically—your company's database standards, authentication requirements, and deployment policies seamlessly integrate into every specification.
+仕様プロセス全体を通じて、リサーチエージェントが重要なコンテキストを収集します。ライブラリの互換性、パフォーマンスベンチマーク、セキュリティの影響を調査します。組織の制約が自動的に発見され、適用されます。たとえば、会社のデータベース標準、認証要件、デプロイメントポリシーがすべての仕様にシームレスに統合されます。
 
-From the PRD, AI generates implementation plans that map requirements to technical decisions. Every technology choice has documented rationale. Every architectural decision traces back to specific requirements. Throughout this process, consistency validation continuously improves quality. AI analyzes specifications for ambiguity, contradictions, and gaps—not as a one-time gate, but as an ongoing refinement.
+PRDから、AIは要件を技術的な決定にマッピングする実装計画を生成します。すべての技術選択には文書化された根拠があります。すべてのアーキテクチャ決定は特定の要件に遡ります。このプロセス全体を通じて、一貫性の検証が品質を継続的に向上させます。AIは、曖昧さ、矛盾、ギャップについて仕様を分析します。これは一度限りのゲートではなく、継続的な改善プロセスです。
 
-Code generation begins as soon as specifications and their implementation plans are stable enough, but they do not have to be "complete." Early generations might be exploratory—testing whether the specification makes sense in practice. Domain concepts become data models. User stories become API endpoints. Acceptance scenarios become tests. This merges development and testing through specification—test scenarios aren't written after code, they're part of the specification that generates both implementation and tests.
+仕様とその実装計画が十分に安定すると、コード生成が開始されますが、「完成」している必要はありません。初期の生成は探索的である場合があります。仕様が実際に意味をなすかどうかをテストします。ドメインの概念はデータモデルになります。ユーザーストーリーはAPIエンドポイントになります。受け入れシナリオはテストになります。これにより、仕様を通じて開発とテストが統合されます。テストシナリオはコードの後に書かれるのではなく、実装とテストの両方を生成する仕様の一部です。
 
-The feedback loop extends beyond initial development. Production metrics and incidents don't just trigger hotfixes—they update specifications for the next regeneration. Performance bottlenecks become new non-functional requirements. Security vulnerabilities become constraints that affect all future generations. This iterative dance between specification, implementation, and operational reality is where true understanding emerges and where the traditional SDLC transforms into a continuous evolution.
+フィードバックループは初期開発を超えて拡張されます。運用メトリクスやインシデントは、ホットフィックスをトリガーするだけでなく、次回の再生成のために仕様を更新します。パフォーマンスのボトルネックは新しい非機能要件になります。セキュリティの脆弱性は、すべての将来の生成に影響を与える制約になります。この仕様、実装、運用現実の間の反復的なダンスが、真の理解が生まれる場所であり、従来のSDLCが継続的な進化に変わる場所です。
 
-## Why SDD Matters Now
+## なぜ今SDDが重要なのか
 
-Three trends make SDD not just possible but necessary:
+3つのトレンドがSDDを可能にし、必要不可欠なものにしています：
 
-First, AI capabilities have reached a threshold where natural language specifications can reliably generate working code. This isn't about replacing developers—it's about amplifying their effectiveness by automating the mechanical translation from specification to implementation. It can amplify exploration and creativity, it can support "start-over" easily, it supports addition subtraction and critical thinking.
+1つ目、AIの能力が自然言語仕様から信頼性の高い動作コードを生成できる閾値に達しました。これは開発者を置き換えるものではなく、仕様から実装への機械的な変換を自動化することで彼らの効果を増幅するものです。探索と創造性を増幅し、「やり直し」を容易にし、追加や削除、批判的思考をサポートします。
 
-Second, software complexity continues to grow exponentially. Modern systems integrate dozens of services, frameworks, and dependencies. Keeping all these pieces aligned with original intent through manual processes becomes increasingly difficult. SDD provides systematic alignment through specification-driven generation. Frameworks may evolve to provide AI-first support, not human-first support, or architect around reusable components.
+2つ目、ソフトウェアの複雑さが指数関数的に増加し続けています。現代のシステムは、数十のサービス、フレームワーク、依存関係を統合しています。手動プロセスを通じてこれらすべての部分を元の意図と一致させ続けることはますます困難になっています。SDDは、仕様駆動の生成を通じて体系的な整合性を提供します。フレームワークは、人間中心ではなくAI中心のサポートを提供するよう進化するか、再利用可能なコンポーネントを中心に設計される可能性があります。
 
-Third, the pace of change accelerates. Requirements change far more rapidly today than ever before. Pivoting is no longer exceptional—it's expected. Modern product development demands rapid iteration based on user feedback, market conditions, and competitive pressures. Traditional development treats these changes as disruptions. Each pivot requires manually propagating changes through documentation, design, and code. The result is either slow, careful updates that limit velocity, or fast, reckless changes that accumulate technical debt.
+3つ目、変化のペースが加速しています。要件はこれまで以上に急速に変化します。ピボットはもはや例外ではなく、期待されるものです。現代のプロダクト開発は、ユーザーフィードバック、市場状況、競争圧力に基づいて迅速な反復を要求します。従来の開発では、これらの変更を混乱として扱います。各ピボットは、文書化、設計、コードを手動で伝播する必要があります。その結果、速度を制限する慎重な更新か、技術的負債を蓄積する迅速で無謀な変更のいずれかになります。
 
-SDD can support what-if/simulation experiments, "If we need to re-implement or change the application to promote a business need to sell more T-shirts, how would we implement and experiment for that?".
+SDDは、「もしアプリケーションを再実装または変更してビジネスニーズを促進し、Tシャツをより多く販売する必要がある場合、どのように実装し、実験するか？」といったシミュレーション実験をサポートできます。
 
-SDD transforms requirement changes from obstacles into normal workflow. When specifications drive implementation, pivots become systematic regenerations rather than manual rewrites. Change a core requirement in the PRD, and affected implementation plans update automatically. Modify a user story, and corresponding API endpoints regenerate. This isn't just about initial development—it's about maintaining engineering velocity through inevitable changes.
+SDDは、要件の変更を障害ではなく通常のワークフローに変えます。仕様が実装を駆動する場合、ピボットは手動の書き換えではなく体系的な再生成になります。PRDのコア要件を変更すると、影響を受けた実装計画が自動的に更新されます。ユーザーストーリーを変更すると、対応するAPIエンドポイントが再生成されます。これは初期開発だけでなく、避けられない変更を通じてエンジニアリングの速度を維持することに関するものです。
 
-## Core Principles
+## コア原則
 
-**Specifications as the Lingua Franca**: The specification becomes the primary artifact. Code becomes its expression in a particular language and framework. Maintaining software means evolving specifications.
+**共通言語としての仕様書**: 仕様書が主要な成果物となります。コードは特定の言語やフレームワークでの表現となります。ソフトウェアの保守は仕様書の進化を意味します。
 
-**Executable Specifications**: Specifications must be precise, complete, and unambiguous enough to generate working systems. This eliminates the gap between intent and implementation.
+**実行可能な仕様書**: 仕様書は、動作するシステムを生成するのに十分な正確さ、完全性、曖昧さのなさを持つ必要があります。これにより、意図と実装のギャップが排除されます。
 
-**Continuous Refinement**: Consistency validation happens continuously, not as a one-time gate. AI analyzes specifications for ambiguity, contradictions, and gaps as an ongoing process.
+**継続的な改善**: 一貫性の検証は一度限りのゲートではなく、継続的に行われます。AIは、曖昧さ、矛盾、ギャップについて仕様を分析します。
 
-**Research-Driven Context**: Research agents gather critical context throughout the specification process, investigating technical options, performance implications, and organizational constraints.
+**リサーチ駆動のコンテキスト**: リサーチエージェントが仕様プロセス全体を通じて重要なコンテキストを収集し、技術的な選択肢、パフォーマンスの影響、組織の制約を調査します。
 
-**Bidirectional Feedback**: Production reality informs specification evolution. Metrics, incidents, and operational learnings become inputs for specification refinement.
+**双方向フィードバック**: 運用現実が仕様の進化を通知します。メトリクス、インシデント、運用から得られた学びが仕様の改善の入力となります。
 
-**Branching for Exploration**: Generate multiple implementation approaches from the same specification to explore different optimization targets—performance, maintainability, user experience, cost.
+**探索のためのブランチング**: 同じ仕様から複数の実装アプローチを生成し、パフォーマンス、保守性、ユーザーエクスペリエンス、コストなどの異なる最適化目標を探索します。
 
-## Implementation Approaches
+## 実装アプローチ
 
-Today, practicing SDD requires assembling existing tools and maintaining discipline throughout the process. The methodology can be practiced with:
+今日、SDDを実践するには、既存のツールを組み合わせ、このプロセス全体を通じて規律を維持する必要があります。この方法論は以下を使用して実践できます：
 
-- AI assistants for iterative specification development
-- Research agents for gathering technical context
-- Code generation tools for translating specifications to implementation
-- Version control systems adapted for specification-first workflows
-- Consistency checking through AI analysis of specification documents
+- 反復的な仕様開発のためのAIアシスタント
+- 技術的なコンテキストを収集するためのリサーチエージェント
+- 仕様を実装に変換するコード生成ツール
+- 仕様優先のワークフローに適応したバージョン管理システム
+- 仕様文書のAI分析による一貫性チェック
 
-The key is treating specifications as the source of truth, with code as the generated output that serves the specification rather than the other way around.
+重要なのは、仕様書を真実の源泉とし、コードを仕様に従属する生成された成果物として扱うことです。
 
-## Streamlining SDD with Claude Commands
+## ClaudeコマンドによるSDDの効率化
 
-The SDD methodology is significantly enhanced through two powerful Claude commands that automate the specification and planning workflow:
+SDDの方法論は、仕様と計画のワークフローを自動化する2つの強力なClaudeコマンドによって大幅に強化されます。
 
-### The `new_feature` Command
+### `new_feature` コマンド
 
-This command transforms a simple feature description (the user-prompt) into a complete, structured specification with automatic repository management:
+このコマンドは、シンプルな機能の説明（ユーザープロンプト）を完全で構造化された仕様に変換し、自動的にリポジトリを管理します：
 
-1. **Automatic Feature Numbering**: Scans existing specs to determine the next feature number (e.g., 001, 002, 003)
-2. **Branch Creation**: Generates a semantic branch name from your description and creates it automatically
-3. **Template-Based Generation**: Copies and customizes the feature specification template with your requirements
-4. **Directory Structure**: Creates the proper `specs/[branch-name]/` structure for all related documents
+1. **自動機能番号付け**: 既存の仕様をスキャンして次の機能番号を決定（例: 001, 002, 003）
+2. **ブランチ作成**: 説明からセマンティックなブランチ名を生成し、自動的に作成
+3. **テンプレートベースの生成**: 機能仕様テンプレートをコピーして要件に合わせてカスタマイズ
+4. **ディレクトリ構造**: 関連するすべてのドキュメントのために`specs/[branch-name]/`構造を作成
 
-### The `generate_plan` Command
+### `generate_plan` コマンド
 
-Once a feature specification exists, this command creates a comprehensive implementation plan:
+機能仕様が存在すると、このコマンドは包括的な実装計画を作成します：
 
-1. **Specification Analysis**: Reads and understands the feature requirements, user stories, and acceptance criteria
-2. **Constitutional Compliance**: Ensures alignment with project constitution and architectural principles
-3. **Technical Translation**: Converts business requirements into technical architecture and implementation details
-4. **Detailed Documentation**: Generates supporting documents for data models, API contracts, and test scenarios
-5. **Manual Testing Plans**: Creates step-by-step validation procedures for each user story
+1. **仕様分析**: 機能要件、ユーザーストーリー、受け入れ基準を読み取り理解
+2. **憲法準拠**: プロジェクト憲法とアーキテクチャ原則との整合性を確保
+3. **技術的翻訳**: ビジネス要件を技術アーキテクチャと実装の詳細に変換
+4. **詳細な文書化**: データモデル、API契約、テストシナリオのサポート文書を生成
+5. **手動テスト計画**: 各ユーザーストーリーのステップバイステップの検証手順を作成
 
-### Example: Building a Chat Feature
+### 例: チャット機能の構築
 
-Here's how these commands transform the traditional development workflow:
+これらのコマンドが従来の開発ワークフローをどのように変革するかを示します：
 
-**Traditional Approach:**
+**従来のアプローチ:**
 ```
-1. Write a PRD in a document (2-3 hours)
-2. Create design documents (2-3 hours)
-3. Set up project structure manually (30 minutes)
-4. Write technical specifications (3-4 hours)
-5. Create test plans (2 hours)
-Total: ~12 hours of documentation work
+1. ドキュメントでPRDを書く（2〜3時間）
+2. 設計文書を作成（2〜3時間）
+3. プロジェクト構造を手動で設定（30分）
+4. 技術仕様を書く（3〜4時間）
+5. テスト計画を作成（2時間）
+合計: ~12時間の文書作業
 ```
 
-**SDD with Commands Approach:**
+**SDDとコマンドのアプローチ:**
 ```bash
-# Step 1: Create the feature specification (5 minutes)
-/new_feature Real-time chat system with message history and user presence
+# ステップ1: 機能仕様を作成（5分）
+/new_feature リアルタイムチャットシステム（メッセージ履歴とユーザーの存在感を含む）
 
-# This automatically:
-# - Creates branch "003-chat-system"
-# - Generates specs/003-chat-system/feature-spec.md
-# - Populates it with structured requirements
+# これにより自動的に以下が行われます：
+# - ブランチ"003-chat-system"を作成
+# - specs/003-chat-system/feature-spec.mdを生成
+# - 構造化された要件で内容を埋める
 
-# Step 2: Generate implementation plan (10 minutes)
-/generate_plan WebSocket for real-time messaging, PostgreSQL for history, Redis for presence
+# ステップ2: 実装計画を生成（10分）
+/generate_plan WebSocketを使用したリアルタイムメッセージング、PostgreSQLを使用した履歴、Redisを使用した存在感
 
-# This automatically creates:
+# これにより以下が自動的に作成されます：
 # - specs/003-chat-system/implementation-plan.md
 # - specs/003-chat-system/implementation-details/
-#   - 00-research.md (WebSocket library comparisons)
-#   - 02-data-model.md (Message and User schemas)
-#   - 03-api-contracts.md (WebSocket events, REST endpoints)
-#   - 06-contract-tests.md (Message flow scenarios)
-#   - 08-inter-library-tests.md (Database-WebSocket integration)
+#   - 00-research.md（WebSocketライブラリの比較）
+#   - 02-data-model.md（メッセージとユーザースキーマ）
+#   - 03-api-contracts.md（WebSocketイベント、RESTエンドポイント）
+#   - 06-contract-tests.md（メッセージフローシナリオ）
+#   - 08-inter-library-tests.md（データベース-WebSocket統合）
 # - specs/003-chat-system/manual-testing.md
 ```
 
-In 15 minutes, you have:
-- A complete feature specification with user stories and acceptance criteria
-- A detailed implementation plan with technology choices and rationale
-- API contracts and data models ready for code generation
-- Comprehensive test scenarios for both automated and manual testing
-- All documents properly versioned in a feature branch
+15分で以下が得られます：
+- ユーザーストーリーと受け入れ基準を含む完全な機能仕様
+- 技術選択とその根拠を含む詳細な実装計画
+- コード生成の準備が整ったAPI契約とデータモデル
+- 自動テストと手動テストの両方の包括的なテストシナリオ
+- すべてのドキュメントが機能ブランチに適切にバージョン管理
 
-### The Power of Structured Automation
+### 構造化された自動化の力
 
-These commands don't just save time—they enforce consistency and completeness:
+これらのコマンドは時間を節約するだけでなく、一貫性と完全性を強制します：
 
-1. **No Forgotten Details**: Templates ensure every aspect is considered, from non-functional requirements to error handling
-2. **Traceable Decisions**: Every technical choice links back to specific requirements
-3. **Living Documentation**: Specifications stay in sync with code because they generate it
-4. **Rapid Iteration**: Change requirements and regenerate plans in minutes, not days
+1. **詳細の見落としなし**: テンプレートにより、非機能要件からエラーハンドリングまで、すべての側面が考慮されます
+2. **追跡可能な決定**: すべての技術的選択が特定の要件にリンクされます
+3. **生きた文書**: 仕様がコードと同期し続けるため、コードを生成します
+4. **迅速な反復**: 要件を変更し、計画を数分で再生成
 
-The commands embody SDD principles by treating specifications as executable artifacts rather than static documents. They transform the specification process from a necessary evil into the driving force of development.
+これらのコマンドは、仕様を静的な文書ではなく、実行可能な成果物として扱うことで、SDDの原則を体現しています。仕様プロセスを必要悪から開発の推進力に変えます。
 
 ### Template-Driven Quality: How Structure Constrains LLMs for Better Outcomes
 


### PR DESCRIPTION
The spec-driven.md document was translated from English to Japanese, including section titles, explanations, and example workflows. This update makes the content accessible to Japanese-speaking developers and teams.